### PR TITLE
che-starter #257: Removing 'wsmaster' from endpoints to make them che6 compatible

### DIFF
--- a/src/main/java/io/fabric8/che/vertx/server/ServerEndpoints.java
+++ b/src/main/java/io/fabric8/che/vertx/server/ServerEndpoints.java
@@ -26,8 +26,8 @@ public class ServerEndpoints {
 	public static final String CREATE_WORKSPACE = "/api/chevertxwsid13/wsagent/project/batch";
 	
 	// WS master
-	public static final String SET_GITHUB_TOKEN = "/wsmaster/api/token/github";
-	public static final String WS_MASTER_PREFERENCES = "/wsmaster/api/preferences";
+	public static final String SET_GITHUB_TOKEN = "/api/token/github";
+	public static final String WS_MASTER_PREFERENCES = "/api/preferences";
 			
 	// OpenShift endpoints
 	public static final String OPENSHIFT_ROUTE = "/oapi/v1/namespaces/" + Properties.DEFAULT_OPENSHIFT_PROJECT


### PR DESCRIPTION
che-starter issue - https://github.com/redhat-developer/che-starter/issues/257
che issue - https://github.com/eclipse/che/issues/6481